### PR TITLE
Fix bug in ArgumentParser

### DIFF
--- a/src/ArgumentParser.cpp
+++ b/src/ArgumentParser.cpp
@@ -17,14 +17,14 @@ namespace cmake::language
     {
       result.children.push_back(*tmp);
       result.range = Range{ r.begin, tmp->range.end };
-      return tmp;
+      return result;
     }
     tmp = Parser<ElementType::QuotedArgument>{}.Parse(r);
     if (tmp)
     {
       result.children.push_back(*tmp);
       result.range = Range{ r.begin, tmp->range.end };
-      return tmp;
+      return result;
     }
     tmp = Parser<ElementType::UnquotedArgument>{}.Parse(r);
     if (tmp)

--- a/tests/ArgumentParser_tests.cpp
+++ b/tests/ArgumentParser_tests.cpp
@@ -19,6 +19,7 @@ TEST_CASE("ArgumentParser", "[Parser]")
       Range r{ script.begin(), script.end() };
       auto result = parser.Parse(r);
       REQUIRE(result);
+      REQUIRE(result.value().type == ElementType::Argument);
       REQUIRE(result.value().range == r);
     }
 
@@ -28,6 +29,7 @@ TEST_CASE("ArgumentParser", "[Parser]")
       Range r{ script.begin(), script.end() };
       auto result = parser.Parse(r);
       REQUIRE(result);
+      REQUIRE(result.value().type == ElementType::Argument);
       REQUIRE(result.value().range == r);
     }
 
@@ -37,6 +39,7 @@ TEST_CASE("ArgumentParser", "[Parser]")
       Range r{ script.begin(), script.end() };
       auto result = parser.Parse(r);
       REQUIRE(result);
+      REQUIRE(result.value().type == ElementType::Argument);
       REQUIRE(result.value().range == r);
     }
   }


### PR DESCRIPTION
 When parsing BracketArgument/QuotedArgument, the parser returned
 respectively the BracketArgument/QuotedArgument instead of the Argument.