### PR TITLE
Fix BracketComment parser

### DIFF
--- a/src/BracketCommentParser.cpp
+++ b/src/BracketCommentParser.cpp
@@ -25,6 +25,7 @@ namespace cmake::language
     {
       return tmp;
     }
+    result.children = std::move(tmp.value().children);
     result.range = Range{ r.begin, tmp->range.end };
     return result;
   }

--- a/tests/BracketCommentParser_tests.cpp
+++ b/tests/BracketCommentParser_tests.cpp
@@ -20,6 +20,8 @@ TEST_CASE("BracketCommentParser", "[Parser]")
       auto result = parser.Parse(r);
       REQUIRE(result);
       REQUIRE(result.value().range == r);
+      // Bracket open, content and close.
+      REQUIRE(result.value().children.size() == 3);
     }
   }
 


### PR DESCRIPTION
 The parser did not add the BracketOpen, BracketContent and BracketClose
 children.