### PR TITLE
The CommandInvocationParser should not change the range of the Idenfier

### DIFF
--- a/src/CommandInvocationParser.cpp
+++ b/src/CommandInvocationParser.cpp
@@ -23,13 +23,7 @@ namespace cmake::language
     tl::expected<Token, Error> ParseIdentifier(Range r)
     {
       auto newRange = IgnoreSpaces(r);
-      auto identifier = Parser<ElementType::Identifier>{}.Parse(newRange);
-      if (identifier)
-      {
-        // Make sure we take into account the spaces
-        identifier->range.begin = r.begin;
-      }
-      return identifier;
+      return Parser<ElementType::Identifier>{}.Parse(newRange);
     }
 
     //-----------------------------------------------------------------------------
@@ -98,7 +92,7 @@ namespace cmake::language
     }
     result.children.push_back(*args);
 
-    result.range = Range{ identifier->range.begin, args->range.end };
+    result.range = Range{ r.begin, args->range.end };
     return result;
   }
 }

--- a/tests/CommandInvocationParser_tests.cpp
+++ b/tests/CommandInvocationParser_tests.cpp
@@ -47,6 +47,9 @@ TEST_CASE("CommandInvocationParser", "[Parser]")
       Range r{ script.begin(), script.end() };
       auto result = parser.Parse(r);
       REQUIRE(result);
+      REQUIRE(result->children.size() > 0);
+      REQUIRE(result->children[0].type == ElementType::Identifier);
+      REQUIRE(result->children[0].range == Range{ script.begin() + 1, script.begin() + 4 });
       REQUIRE(result.value().range == r);
     }
 

--- a/tests/IdentifierParser_tests.cpp
+++ b/tests/IdentifierParser_tests.cpp
@@ -34,6 +34,14 @@ TEST_CASE("IdentifierParser", "[Parser]")
       REQUIRE(!result);
     }
 
+    SECTION("Start with some spaces")
+    {
+      auto script = "\nbad"sv;
+      Range r{ script.begin(), script.end() };
+      auto result = parser.Parse(r);
+      REQUIRE(!result);
+    }
+
     SECTION("Use special characters")
     {
       auto script = "dollar_$_is_not_valid"sv;


### PR DESCRIPTION
 The CommandInvocation range should contain the precending spaces, but
 the underlying Identifier should not.